### PR TITLE
Fixed gautschi userguide back links

### DIFF
--- a/docs/userguides/gautschi/run_jobs/apptainer_example.md
+++ b/docs/userguides/gautschi/run_jobs/apptainer_example.md
@@ -117,4 +117,4 @@ apptainer build ubuntu-18.04.sif ubuntu-18.04
 
 Finally, copy the new image to Gautschi and run it.
 
-[Return to the Guide](../run_jobs/index.md)
+[**Back to the Running Jobs section**](../run_jobs/index.md)

--- a/docs/userguides/gautschi/run_jobs/cancelling_job.md
+++ b/docs/userguides/gautschi/run_jobs/cancelling_job.md
@@ -14,4 +14,4 @@ To stop a job before it finishes or remove it from a queue, use the ```scancel``
 scancel myjobid
 ```
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/checking_output.md
+++ b/docs/userguides/gautschi/run_jobs/checking_output.md
@@ -27,4 +27,4 @@ It is possible to redirect job output to somewhere other than the default locati
 echo "Hello World"
 ```
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/creating_the_submission_script.md
+++ b/docs/userguides/gautschi/run_jobs/creating_the_submission_script.md
@@ -31,4 +31,4 @@ cd $SLURM_SUBMIT_DIR
 matlab -nodisplay -singleCompThread -r myscript
 ```
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/directives.md
+++ b/docs/userguides/gautschi/run_jobs/directives.md
@@ -39,4 +39,4 @@ This job can be then submitted with:
 sbatch hello.sub
 ```
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/examples/example_installing_r_packages.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_installing_r_packages.md
@@ -109,4 +109,4 @@ For more information about installing R packages:
 - [Installing additional R packages on Linux :octicons-link-external-16:](http://cran.r-project.org/doc/manuals/r-release/R-admin.html#Installing-packages)
 - [List of Packages :octicons-link-external-16:](https://cran.r-project.org/web/packages/)
 
-[Return to the Guide](../r_example.md)
+[**Back to the R Examples section**](../r_example.md)

--- a/docs/userguides/gautschi/run_jobs/examples/example_loading_into_r.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_loading_into_r.md
@@ -34,4 +34,4 @@ For more functions and tutorials:
 - [Software Carpentry - Programming with R :octicons-link-external-16:](https://swcarpentry.github.io/r-novice-inflammation/)
 - [Data Carpentry Lessons :octicons-link-external-16:](http://www.datacarpentry.org/lessons/)
 
-[Return to the Guide](../r_example.md)
+[**Back to the R Examples section**](../r_example.md)

--- a/docs/userguides/gautschi/run_jobs/examples/example_python_job.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_python_job.md
@@ -93,4 +93,4 @@ For more information about Python:
 - [**Anaconda Python Distribution - Official Website** :octicons-link-external-16:](https://store.continuum.io/cshop/anaconda/)
 - [**Conda User Guide** :octicons-link-external-16:](https://conda.io/projects/conda/en/latest/user-guide/)
 
-[Return to the Guide](../python_example.md)
+[**Back to the Python Examples section**](../python_example.md)

--- a/docs/userguides/gautschi/run_jobs/examples/example_rstudio.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_rstudio.md
@@ -37,4 +37,4 @@ R and RStudio are free to download and run on your local machine. For more infor
 - [RStudio Essentials: Tutorial :octicons-link-external-16:](https://www.rstudio.com/resources/webinars/#rstudioessentials)
 - [DataCamp: Working with the RStudio IDE :octicons-link-external-16:](https://www.datacamp.com/courses/working-with-the-rstudio-ide-part-1)
 
-[Return to the Guide](../r_example.md)
+[**Back to the R Examples section**](../r_example.md)

--- a/docs/userguides/gautschi/run_jobs/examples/example_running_r_jobs.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_running_r_jobs.md
@@ -44,4 +44,4 @@ For other examples or R jobs:
 - [Software Carpentry - Programming with R :octicons-link-external-16:](https://swcarpentry.github.io/r-novice-inflammation/)
 - [Data Carpentry Lessons :octicons-link-external-16:](http://www.datacarpentry.org/lessons/)
 
-[Return to the Guide](../r_example.md)
+[**Back to the R Examples section**](../r_example.md)

--- a/docs/userguides/gautschi/run_jobs/generic_slurm_jobs.md
+++ b/docs/userguides/gautschi/run_jobs/generic_slurm_jobs.md
@@ -19,4 +19,4 @@ There are several types of generic SLURM jobs. Choose one below to learn more:
 - [**Monitoring Resources**](monitoring_resources.md)
 
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/gpu_usage_monitoring.md
+++ b/docs/userguides/gautschi/run_jobs/gpu_usage_monitoring.md
@@ -100,5 +100,5 @@ Further, the ```--job {jobid}``` flag will also allow you to query the utilizati
 - ### "Is this a good way to see the GPU Hours balance?"
  No, the primary purpose of this tool is to check that GPUs are actually being used, not to track billed GPU hours. To see the total GPU hours balance, please use the ```slist``` command.
 
- [Return to the Guide](../run_jobs/index.md)
+ [**Back to the Running Jobs section**](../run_jobs/index.md)
  

--- a/docs/userguides/gautschi/run_jobs/holding_job.md
+++ b/docs/userguides/gautschi/run_jobs/holding_job.md
@@ -24,4 +24,4 @@ To release a hold on a job, use the ```scontrol release job``` command:
 $ scontrol release job  myjobid
 ```
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/interactive_jobs.md
+++ b/docs/userguides/gautschi/run_jobs/interactive_jobs.md
@@ -26,4 +26,4 @@ exit or Ctrl-D
 
 The above example will allocate the total of 384 CPU cores across 2 nodes. Note that if your multi-node job requests fewer than each node's full 192 cores per node, by default Slurm provides no guarantee with respect to how this total is distributed between assigned nodes (i.e. the cores may not necessarily be split evenly). If you need specific arrangements of your tasks and cores, you can use ```--cpus-per-task=``` and/or ```--ntasks-per-node=``` flags. See [Slurm documentation :octicons-link-external-16:](https://slurm.schedmd.com/salloc.html) or ```man salloc``` for more options.
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/job_dependencies.md
+++ b/docs/userguides/gautschi/run_jobs/job_dependencies.md
@@ -44,4 +44,4 @@ To set more complex dependencies on multiple jobs and conditions:
 sbatch --dependency=after:myjobid1:myjobid2:myjobid3,afterok:myjobid4 myjobsubmissionfile
 ```
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/monitoring_job.md
+++ b/docs/userguides/gautschi/run_jobs/monitoring_job.md
@@ -68,4 +68,4 @@ Nodes, CPUs, Tasks, and - CPUs per Task are shown.
 
 - ```WorkDir``` is the job's working directory.
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/monitoring_resources.md
+++ b/docs/userguides/gautschi/run_jobs/monitoring_resources.md
@@ -85,4 +85,4 @@ mpiexec -machinefile <(srun hostname | sort -u) \
     monitor cpu memory --csv --no-header >>cpu-memory.csv
 ```
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/multiple_node.md
+++ b/docs/userguides/gautschi/run_jobs/multiple_node.md
@@ -28,4 +28,4 @@ gautschi-a[014-015]
 
 The above example will allocate the total of 384 CPU cores across 2 nodes. Note that if your multi-node job requests fewer than each node's full 192 cores per node, by default Slurm provides no guarantee with respect to how this total is distributed between assigned nodes (i.e. the cores may not necessarily be split evenly). If you need specific arrangements of your tasks and cores, you can use ```--cpus-per-task=``` and/or ```--ntasks-per-node=``` flags. See [Slurm documentation :octicons-link-external-16:](https://slurm.schedmd.com/sbatch.html) or ```man sbatch``` for more options.
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/python_example.md
+++ b/docs/userguides/gautschi/run_jobs/python_example.md
@@ -23,4 +23,4 @@ $ module spider conda
 - [**Example Python Jobs**](examples/example_python_job.md)
 
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/run_jobs/r_example.md
+++ b/docs/userguides/gautschi/run_jobs/r_example.md
@@ -17,4 +17,4 @@ For more general information on R visit [The R Project for Statistical Computing
 - [RStudio](examples/example_rstudio.md)
 - [Running R Jobs](examples/example_running_r_jobs.md)
 
-[Return to the Guide](../run_jobs/index.md)
+[**Back to the Running Jobs section**](../run_jobs/index.md)

--- a/docs/userguides/gautschi/run_jobs/serial_jobs.md
+++ b/docs/userguides/gautschi/run_jobs/serial_jobs.md
@@ -36,4 +36,4 @@ hello, world
 
 If the job failed to run, then view error messages in the file ```slurm-myjobid.out```.
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/simple_job.md
+++ b/docs/userguides/gautschi/run_jobs/simple_job.md
@@ -46,4 +46,4 @@ Hello World
 
 You should see the hostname of the compute node your job was executed on. Following should be the "Hello World" statement.
 
-[**Return to the guide**](generic_slurm_jobs.md)
+[**Back to the Example Jobs section**](generic_slurm_jobs.md)

--- a/docs/userguides/gautschi/run_jobs/submit_script.md
+++ b/docs/userguides/gautschi/run_jobs/submit_script.md
@@ -29,4 +29,4 @@ sbatch -A myLabAccount -p cpu -q normal -N1 -n1 -t 1-00:00:00 myjobsubmissionfil
 !!! note
     Any sbatch options that you specify in the command-line submission will override what is specified in your job submission script.
 
-[**Return to the guide**](index.md)
+[**Back to the Running Jobs section**](index.md)

--- a/docs/userguides/gautschi/storage/archive_and_compression.md
+++ b/docs/userguides/gautschi/storage/archive_and_compression.md
@@ -80,4 +80,4 @@ There are several other, less commonly used, options available as well:
 - 7zip
 - xz
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/environment_variables.md
+++ b/docs/userguides/gautschi/storage/environment_variables.md
@@ -58,4 +58,4 @@ To assign a value to an environment variable in either tcsh or csh:
 $ setenv MYPROJECT value
 ```
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/ftp_sftp.md
+++ b/docs/userguides/gautschi/storage/ftp_sftp.md
@@ -75,4 +75,4 @@ The ```sftp``` command-line program should already be installed. You may start a
 
 [Cyberduck :octicons-link-external-16:](https://cyberduck.io/) is a full-featured and free graphical SFTP and SCP client.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/globus.md
+++ b/docs/userguides/gautschi/storage/globus.md
@@ -51,4 +51,4 @@ Globus allows convenient sharing of data with outside collaborators. Data can be
 
 For links to more information, please see [Globus Support :octicons-link-external-16:](https://support.globus.org/home) page and [RCAC Globus presentation :octicons-link-external-16:](https://www.rcac.purdue.edu/training/globus).
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/home_directory.md
+++ b/docs/userguides/gautschi/storage/home_directory.md
@@ -40,4 +40,4 @@ Your home directory is medium-performance, non-purged space suitable for tasks l
 !!!note
     Your home directory is not designed or intended for use as high-performance working space for running data-intensive jobs with heavy I/O demands.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/hsi.md
+++ b/docs/userguides/gautschi/storage/hsi.md
@@ -88,4 +88,4 @@ For more information about HSI:
 - [HSI Reference Manual :octicons-link-external-16:](https://rcac.purdue.edu/files/hpss/hsi_9.3_reference_manual.pdf)
 - [Lawrence Livermore National Lab HSI User Guide :octicons-link-external-16:](https://hpc.llnl.gov/documentation/user-guides/using-hsi-hierarchical-storage-interface)
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/htar.md
+++ b/docs/userguides/gautschi/storage/htar.md
@@ -116,4 +116,4 @@ For more information about HTAR:
 !!!important
     HTAR has an individual file size limit of 64GB. If any files you are trying to archive with HTAR are greater than 64GB, then HTAR will immediately fail. This does not limit the number of files in the archive or the total overall size of the archive. To get around this limitation, try using the ```htar_large``` command. It is slower than using ```htar``` but it will work around the 64GB file size limit. The usage of ```htar_large``` is almost the same as ```htar``` except that ```htar_large``` will not generate the tar index file. Thus, the ```-Hverify=1``` option cannot be used since it's based on the index file. This does not limit the number of files in the archive or the total overall size of the archive.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/long_term_storage.md
+++ b/docs/userguides/gautschi/storage/long_term_storage.md
@@ -15,4 +15,4 @@ For more information about Fortress, how it works, and user guides, and how to o
 - [Fortress Information PLACEHOLDER]()
 - [Fortress User Guide PLACEHOLDER]()
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/scp.md
+++ b/docs/userguides/gautschi/storage/scp.md
@@ -76,4 +76,4 @@ The ```scp``` command-line program should already be installed. You may start a 
 
 [Cyberduck :octicons-link-external-16:](https://cyberduck.io/) is a full-featured and free graphical SFTP and SCP client.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/scratch_space.md
+++ b/docs/userguides/gautschi/storage/scratch_space.md
@@ -39,4 +39,4 @@ $ echo $RCAC_SCRATCH
 
 Your scratch directory is located on a high-performance, large-capacity parallel filesystem engineered to provide work-area storage optimized for a wide variety of job types. It is designed to perform well with data-intensive computations, while scaling well to large numbers of simultaneous connections.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/sharing.md
+++ b/docs/userguides/gautschi/storage/sharing.md
@@ -32,4 +32,4 @@ Your research group can easily share static files (images, data, HTML) from your
 
 Note that it is not possible to run web sites, dynamic content, interpreters (PHP, Perl, Python), or CGI scripts from this web site.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/storage_quota.md
+++ b/docs/userguides/gautschi/storage/storage_quota.md
@@ -64,4 +64,4 @@ If you find you need additional disk space in your home directory, please consid
 
 If you find you need additional disk space in your scratch space, please first consider archiving and compressing old files and moving them to long-term storage on the Fortress HPSS Archive. If you are unable to do so, you may ask for a quota increase by contacting support.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/tmp_directory.md
+++ b/docs/userguides/gautschi/storage/tmp_directory.md
@@ -12,4 +12,4 @@ search:
 
 Backups are not performed for the ```/tmp``` directory and removes files from ```/tmp``` whenever space is low or whenever the system needs a reboot. In the event of a disk crash or file purge, files in ```/tmp``` are **not recoverable**. You should copy any important files to more permanent storage.
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)

--- a/docs/userguides/gautschi/storage/windows_network_drive.md
+++ b/docs/userguides/gautschi/storage/windows_network_drive.md
@@ -64,4 +64,4 @@ If you would like access via samba on the command line you may install ```smbcli
 !!!note
     Use your career account login name and password when prompted. (You will not need to add ```",push"``` nor use your Purdue Duo client.)
 
-[Return to the Guide](../storage.md)
+[**Back to the Storage section**](../storage.md)


### PR DESCRIPTION
Adjusted the text on the gautschi userguide back links to be more verbose as to which section of the guide it's taking the user. Resolves issue #124