### PR TITLE
Fix placeholder links

### DIFF
--- a/docs/userguides/gautschi/run_jobs/examples/example_rstudio.md
+++ b/docs/userguides/gautschi/run_jobs/examples/example_rstudio.md
@@ -21,11 +21,11 @@ module load rstudio
 rstudio
 ```
 
-Note that RStudio is a graphical program and in order to run it you must have a local X11 server running or use [Thinlinc PLACEHOLDER](https://rcac.purdue.edu/knowledge/gautschi/accounts/login/thinlinc) Remote Desktop environment. See the [ssh X11 forwarding section PLACEHOLDER](https://rcac.purdue.edu/knowledge/gautschi/accounts/login/x11) for more details.
+Note that RStudio is a graphical program and in order to run it you must have a local X11 server running or use [Thinlinc](../../accounts.md#thinlinc) Remote Desktop environment. See the [ssh X11 forwarding section](../../accounts.md#ssh-x11-forwarding) for more details.
 
 ## Launch Rstudio via the application menu icon:
 
-- Log into desktop.gautschi.rcac.purdue.edu with web browser or [ThinLinc PLACEHOLDER](https://rcac.purdue.edu/knowledge/gautschi/accounts/login/thinlinc) client
+- Log into desktop.gautschi.rcac.purdue.edu with web browser or [ThinLinc](../../accounts.md#thinlinc) client
 - Click on the ```Applications``` drop down menu on the top left corner
 - Choose ```Cluster Software``` and then ```RStudio```
 

--- a/docs/userguides/gautschi/storage/home_directory.md
+++ b/docs/userguides/gautschi/storage/home_directory.md
@@ -10,7 +10,7 @@ search:
 
 Home directories are provided for long-term file storage. Each user has one home directory. You should use your home directory for storing important program files, scripts, input data sets, critical results, and frequently used files. You should store infrequently used files on Fortress. Your home directory becomes your current working directory, by default, when you log in.
 
-Daily snapshots of your home directory are provided for a limited period of time in the event of accidental deletion. For additional security, you should store another copy of your files on more permanent storage, such as the [Fortress HPSS Archive PLACEHOLDER]().
+Daily snapshots of your home directory are provided for a limited period of time in the event of accidental deletion. For additional security, you should store another copy of your files on more permanent storage, such as the [Fortress HPSS Archive](https://www.rcac.purdue.edu/storage/fortress).
 
 Your home directory physically resides on a GPFS storage system in the data center. To find the path to your home directory, first log in then immediately enter the following:
 
@@ -31,7 +31,7 @@ $ echo $HOME
 
 ## Lost File Recovery
 
-Nightly snapshots for 7 days, weekly snapshots for 4 weeks, and monthly snapshots for 3 months are kept. This means you will find snapshots from the last 7 nights, the last 4 Sundays, and the last 3 first of the months. Files are available going back between two and three months, depending on how long ago the last first of the month was. Snapshots beyond this are not kept. For additional security, you should store another copy of your files on more permanent storage, such as the [Fortress HPSS Archive PLACEHOLDER]().
+Nightly snapshots for 7 days, weekly snapshots for 4 weeks, and monthly snapshots for 3 months are kept. This means you will find snapshots from the last 7 nights, the last 4 Sundays, and the last 3 first of the months. Files are available going back between two and three months, depending on how long ago the last first of the month was. Snapshots beyond this are not kept. For additional security, you should store another copy of your files on more permanent storage, such as the [Fortress HPSS Archive](https://www.rcac.purdue.edu/storage/fortress).
 
 ## Performance
 

--- a/docs/userguides/gautschi/storage/scratch_space.md
+++ b/docs/userguides/gautschi/storage/scratch_space.md
@@ -10,11 +10,11 @@ search:
 
 Scratch directories are provided for short-term file storage only. The quota of your scratch directory is much greater than the quota of your home directory. You should use your scratch directory for storing temporary input files which your job reads or for writing temporary output files which you may examine after execution of your job. You should use your home directory and Fortress for longer-term storage or for holding critical results. The ```hsi``` and ```htar``` commands provide easy-to-use interfaces into the archive and can be used to copy files into the archive interactively or even automatically at the end of your regular job submission scripts.
 
-!!!warning
+!!!danger
     Files in scratch directories are **not recoverable**. Files in scratch directories are **not backed up**. If you accidentally delete a file, a disk crashes, or old files are purged, they **cannot be restored**.
 
-!!!warning
-    Files that have not been accessed or had content modified in 60 days **are purged**. For more information, please refer to our [Scratch File Purging Policy PLACEHOLDER]().
+!!!danger
+    Files that have not been accessed or had content modified in 60 days **are purged**. For more information, please refer to our [Scratch File Purging Policy](https://www.rcac.purdue.edu/policies/scratchpurge).
 
 All users may access scratch directories on Gautschi. To find the path to your scratch directory:
 


### PR DESCRIPTION
- Fixed placeholder links on the example RStudio page. It now links directly to the Thinlinc subsections. Resolves issue #176

- FIxed placeholder links on scratch_space.md. It now links to the halcyon scratch purge policy page. Also changed warnings about purges to 'danger' to greater stress importance of backing up this data. Resolves issue #177

-Fixed placeholder links on home_directory.md. It now links to the halcyon Fortress uisreguide. Resolves issue #178