### PR TITLE
Fixed a link & other tidying up

### DIFF
--- a/docs/userguides/gautschi/run_jobs/cancelling_job.md
+++ b/docs/userguides/gautschi/run_jobs/cancelling_job.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Cancelling a Job
+
 To stop a job before it finishes or remove it from a queue, use the ```scancel``` command:
 
 ```bash

--- a/docs/userguides/gautschi/run_jobs/checking_output.md
+++ b/docs/userguides/gautschi/run_jobs/checking_output.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Checking the Job Output
+
 Once a job is submitted, and has started, it will write its standard output and standard error to files that you can read.
 
 SLURM catches output written to standard output and standard error - what would be printed to your screen if you ran your program interactively. Unless you specfied otherwise, SLURM will put the output in the directory where you submitted the job in a file named ```slurm-``` followed by the ```job id```, with the extension ```out```. For example ```slurm-3509.out```. Note that both stdout and stderr will be written into the same file, unless you specify otherwise.

--- a/docs/userguides/gautschi/run_jobs/generic_slurm_jobs.md
+++ b/docs/userguides/gautschi/run_jobs/generic_slurm_jobs.md
@@ -9,6 +9,8 @@ search:
   boost: 2
 ---
 
+# Generic SLURM Jobs
+
 There are several types of generic SLURM jobs. Choose one below to learn more:
 
 - [**Simple Job**](simple_job.md)

--- a/docs/userguides/gautschi/run_jobs/holding_job.md
+++ b/docs/userguides/gautschi/run_jobs/holding_job.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Holding a Job
+
 Sometimes you may want to submit a job but not have it run just yet. You may be wanting to allow lab mates to cut in front of you in the queue - so hold the job until their jobs have started, and then release yours.
 
 To place a hold on a job before it starts running, use the ```scontrol hold job``` command:

--- a/docs/userguides/gautschi/run_jobs/monitoring_job.md
+++ b/docs/userguides/gautschi/run_jobs/monitoring_job.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Monitoring the Job
+
 Once a job is submitted there are several commands you can use to monitor the progress of the job.
 
 To see your jobs, use the ```squeue -u``` command and specify your username:

--- a/docs/userguides/gautschi/run_jobs/multiple_node.md
+++ b/docs/userguides/gautschi/run_jobs/multiple_node.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Multiple Node Job
+
 In some cases, you may want to request multiple nodes. To utilize multiple nodes, you will need to have a program or code that is specifically programmed to use multiple nodes such as with MPI. Simply requesting more nodes will not make your work go faster. Your code must support this ability.
 
 This example shows a request for multiple compute nodes. The job submission file contains a single command to show the names of the compute nodes allocated:

--- a/docs/userguides/gautschi/run_jobs/submit_script.md
+++ b/docs/userguides/gautschi/run_jobs/submit_script.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Submitting a Job
+
 Once you have a job submission script, you may submit the script to SLURM using the sbatch command. SLURM will find, or wait for, available resources matching your request and run your job there. If you have included your sbatch options as special comments in your submission script, submitting the job is as simple as:
 
 ``` bash

--- a/docs/userguides/gautschi/software.md
+++ b/docs/userguides/gautschi/software.md
@@ -54,4 +54,4 @@ module load hypershell/2.7.0
 ```
 
 ### Running GUI versions of apps
-If the app you want to use has a GUI, you can also login to {{ resource }} via Thinlinc. More information on this process can be found [here](../../blog/posts/thinlinc-login.md).
+If the app you want to use has a GUI, you can also login to {{ resource }} via Thinlinc. More information on this process can be found [here](accounts.md#thinlinc).

--- a/docs/userguides/gautschi/storage/ftp_sftp.md
+++ b/docs/userguides/gautschi/storage/ftp_sftp.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# FTP / SFTP
+
 !!!warning
     FTP is not supported on any research systems because it does not allow for secure transmission of data. Use SFTP instead, as described below.
 

--- a/docs/userguides/gautschi/storage/long_term_storage.md
+++ b/docs/userguides/gautschi/storage/long_term_storage.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Long-Term Storage
+
 Long-term Storage or Permanent Storage is available to users on the High Performance Storage System (HPSS), an archival storage system, called **Fortress**. Program files, data files and any other files which are **not used often**, but which must be saved, can be put in permanent storage. Fortress currently has over 10PB of capacity.
 
 For more information about Fortress, how it works, and user guides, and how to obtain an account:

--- a/docs/userguides/gautschi/storage/storage_quota.md
+++ b/docs/userguides/gautschi/storage/storage_quota.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Storage Quota / Limits
+
 Some limits are imposed on your disk usage on research systems. A quota is implemented on each filesystem. Each filesystem (home directory, scratch directory, etc.) may have a different limit. If you exceed the quota, you will not be able to save new files or new data to the filesystem until you delete or move data to long-term storage.
 
 ## Checking Quota

--- a/docs/userguides/gautschi/storage/windows_network_drive.md
+++ b/docs/userguides/gautschi/storage/windows_network_drive.md
@@ -8,6 +8,8 @@ search:
   boost: 2
 ---
 
+# Windows Network Drive / SMB
+
 SMB (Server Message Block), also known as CIFS, is an easy-to-use file transfer protocol that is useful for transferring files between RCAC systems and a desktop or laptop. You may use SMB to connect to your home, scratch, and Fortress storage directories. The SMB protocol is available on Windows, Linux, and Mac OS X. It is primarily used as a graphical means of transfer, but it can also be used over the command line.
 
 !!!note


### PR DESCRIPTION
- Fixed a link on software.md page that was pointing to a non-existent thinlinc blog. It now links to accounts.md#thinlinc

- Set page titles on various pages